### PR TITLE
fix(agent): stop completed outgoing-reply artifacts from persisting in the inbox file

### DIFF
--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -574,19 +574,32 @@ func (s *Store) PeekInbox() []a2a.Message {
 func (s *Store) CompleteTask(taskID, replyText string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// Drop inbox entries for this task before the s.tasks lookup. A synthetic
+	// outgoing-reply carries an outgoing task id that is absent from s.tasks,
+	// so the earlier ErrTaskNotFound return skipped this drop and the entry
+	// lingered in the inbox snapshot.
+	filtered := s.inbox[:0]
+	dropped := false
+	for _, m := range s.inbox {
+		if m.TaskID == taskID {
+			dropped = true
+			continue
+		}
+		filtered = append(filtered, m)
+	}
+	if dropped {
+		s.inbox = filtered
+		s.persistInboxLocked()
+	}
+
 	t, ok := s.tasks[taskID]
 	if !ok {
+		if dropped {
+			// cleared a synthetic outgoing-reply; nothing else to complete
+			return nil
+		}
 		return a2a.ErrTaskNotFound
 	}
-	// drop inbox entries for this task
-	filtered := s.inbox[:0]
-	for _, m := range s.inbox {
-		if m.TaskID != taskID {
-			filtered = append(filtered, m)
-		}
-	}
-	s.inbox = filtered
-	s.persistInboxLocked()
 	reply := a2a.Message{
 		MessageID: uuid.NewString(),
 		ContextID: t.ContextID,

--- a/internal/agent/store_test.go
+++ b/internal/agent/store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -387,5 +388,67 @@ func TestTrimToRuneSafe(t *testing.T) {
 	}
 	if short := trimTo("short", 10); short != "short" {
 		t.Errorf("trimTo(short) = %q", short)
+	}
+}
+
+// TestCompleteTaskClearsOutgoingReplyNotification: a synthetic outgoing-reply
+// (its TaskID is an outgoing task, absent from s.tasks) is cleared by
+// CompleteTask rather than returning ErrTaskNotFound, so it does not keep the
+// inbox snapshot non-empty. A second delivery of the same task is a no-op.
+func TestCompleteTaskClearsOutgoingReplyNotification(t *testing.T) {
+	s := NewStore()
+	defer s.Close()
+	s.InboxPath = filepath.Join(t.TempDir(), "inbox.json")
+
+	// peer completes an outgoing task; the SSE fast-path renders the reply.
+	s.TrackOutgoing("out-1", "http://peer/", "peer-A", "What is 2+2?")
+	if !s.IngestOutgoingTerminal(&a2a.Task{
+		ID:     "out-1",
+		Status: a2a.TaskStatus{State: a2a.TaskStateCompleted},
+	}) {
+		t.Fatal("IngestOutgoingTerminal should deliver the tracked reply")
+	}
+
+	// reply is in the inbox and the persisted snapshot.
+	if got := len(s.PeekInbox()); got != 1 {
+		t.Fatalf("inbox len after reply = %d, want 1", got)
+	}
+	before, err := os.ReadFile(s.InboxPath)
+	if err != nil {
+		t.Fatalf("read inbox file: %v", err)
+	}
+	if !strings.Contains(string(before), "out-1") {
+		t.Fatalf("inbox file should contain the outgoing-reply taskId; got %s", before)
+	}
+
+	// ack clears it (was ErrTaskNotFound).
+	if err := s.CompleteTask("out-1", ""); err != nil {
+		t.Fatalf("CompleteTask(outgoing-reply id) = %v, want nil", err)
+	}
+	if got := len(s.PeekInbox()); got != 0 {
+		t.Fatalf("inbox len after ack = %d, want 0 (reply not cleared)", got)
+	}
+	after, err := os.ReadFile(s.InboxPath)
+	if err != nil {
+		t.Fatalf("read inbox file: %v", err)
+	}
+	if strings.Contains(string(after), "out-1") {
+		t.Fatalf("inbox file still retains the outgoing-reply after ack: %s", after)
+	}
+
+	// second delivery is a no-op: pendingOutgoing was deleted on first delivery.
+	if s.IngestOutgoingTerminal(&a2a.Task{
+		ID:     "out-1",
+		Status: a2a.TaskStatus{State: a2a.TaskStateCompleted},
+	}) {
+		t.Fatal("second IngestOutgoingTerminal should be a no-op (already delivered)")
+	}
+	if got := len(s.PeekInbox()); got != 0 {
+		t.Fatalf("inbox len after second ingest = %d, want 0 (reply re-appended)", got)
+	}
+
+	// unknown id with no inbox entry still reports not-found.
+	if err := s.CompleteTask("never-seen", ""); !errors.Is(err, a2a.ErrTaskNotFound) {
+		t.Fatalf("CompleteTask(unknown id) = %v, want ErrTaskNotFound", err)
 	}
 }


### PR DESCRIPTION
## What

CompleteTask now clears a completed outgoing-reply from the inbox on the normal ack.

## Why

The per-agent inbox file holds pending inbound messages and is used as an idle-wake signal. A completed reply to an outgoing task is rendered into it as a synthetic message whose TaskID is the outgoing task's id. That id is not in s.tasks, so CompleteTask returned ErrTaskNotFound before its inbox-drop loop and never removed the entry; it stayed in s.inbox, was re-written to the snapshot on every persist, and kept the file non-empty with nothing pending.

The synthetic append is already idempotent (IngestOutgoingTerminal and PollOutgoing both delete from pendingOutgoing first), so the entry is rendered once. The bug is the missing removal path.

## Fix

Drop inbox entries by task id before the s.tasks lookup, returning nil when a non-local id's entry was dropped. The reply clears on the normal a2a_complete_task ack, the same as inbound tasks. Inbound completion is unchanged.

## Checklist

- [x] `go vet ./...` passes
- [x] `go test ./... -race -count=1` passes locally
- [x] `golangci-lint run` not run (not available locally); go vet + race pass
- [x] `CHANGELOG.md` left unchanged (maintainer-managed)
- [x] README / `--help` unchanged (internal behaviour only)
- [x] No new TODO / FIXME / panic
- [x] No new dependency
