### PR TITLE
fix(agent): suppress empty synthetic replies + evict stale outgoing-reply records

### DIFF
--- a/internal/agent/store.go
+++ b/internal/agent/store.go
@@ -143,6 +143,30 @@ func (s *Store) evictTerminal(now time.Time) int {
 			evicted = append(evicted, id)
 		}
 	}
+	// FIX(stale-re-render): outgoing-reply notifications (MessageID "reply-…") are
+	// one-shot — delivered in real-time via OnIncoming + injected by the wake hook.
+	// The bot never complete_task's its OWN outgoing task IDs, so CompleteTask's
+	// by-taskID drop never reaches them and they re-rendered on every wake. Evict
+	// by IDENTITY (MessageID prefix; `kind` is stripped on-disk) once past the
+	// delivery TTL.
+	if len(s.inbox) > 0 {
+		replyCutoff := now.Add(-10 * time.Minute)
+		kept := s.inbox[:0]
+		for _, m := range s.inbox {
+			if strings.HasPrefix(m.MessageID, "reply-") {
+				if ts, ok := m.Metadata["ts"].(string); ok {
+					if when, err := time.Parse(time.RFC3339, ts); err == nil && when.Before(replyCutoff) {
+						continue // delivered + aged out → drop
+					}
+				}
+			}
+			kept = append(kept, m)
+		}
+		if len(kept) != len(s.inbox) {
+			s.inbox = kept
+			s.persistInboxLocked()
+		}
+	}
 	s.mu.Unlock()
 	for _, id := range evicted {
 		// Empty PushConfigID = delete all webhooks for the task. The
@@ -229,12 +253,19 @@ func extractReplyText(t *a2a.Task) string {
 // poll loop and the SSE fast-path. Holds the lock for as little time as
 // possible and fires OnIncoming outside the critical section.
 func (s *Store) appendSyntheticReply(p *pendingOutgoingTask, reply, state string) {
+	// FIX(empty-arrivals): a contentless completion (peer completed with no reply
+	// text — e.g. a bare a2a_complete_task ack) used to land as an empty "[ОТВЕТ …]"
+	// record: noise that also fed the never-cleared stale floor. The terminal state
+	// is already recorded on the task; a contentless completion needs no inbox entry.
+	if strings.TrimSpace(reply) == "" {
+		return
+	}
 	synthetic := a2a.Message{
 		MessageID: "reply-" + p.TaskID,
 		TaskID:    p.TaskID,
 		Role:      a2a.RoleAgent,
 		Parts:     []a2a.Part{{Text: fmt.Sprintf("[ОТВЕТ от %s на твой вопрос «%s»]\n%s", p.PeerName, trimTo(p.Question, 80), reply)}},
-		Metadata:  map[string]any{"from": p.PeerName, "kind": "outgoing-reply", "state": state},
+		Metadata:  map[string]any{"from": p.PeerName, "kind": "outgoing-reply", "state": state, "ts": time.Now().UTC().Format(time.RFC3339)},
 	}
 	s.mu.Lock()
 	s.inbox = append(s.inbox, synthetic)

--- a/internal/agent/store_test.go
+++ b/internal/agent/store_test.go
@@ -389,3 +389,51 @@ func TestTrimToRuneSafe(t *testing.T) {
 		t.Errorf("trimTo(short) = %q", short)
 	}
 }
+
+// TestIngestOutgoingTerminalSkipsEmptyReply verifies the empty-arrivals fix:
+// a peer completing our outbound task with NO reply text must not land an
+// empty "[ОТВЕТ …]" record in our inbox.
+func TestIngestOutgoingTerminalSkipsEmptyReply(t *testing.T) {
+	s := NewStore()
+	s.TrackOutgoing("task-empty", "http://peer/", "peer-A", "ping?")
+	ok := s.IngestOutgoingTerminal(&a2a.Task{
+		ID:     "task-empty",
+		Status: a2a.TaskStatus{State: a2a.TaskStateCompleted},
+		// no artifacts, no status message → empty reply text
+	})
+	if !ok {
+		t.Fatalf("IngestOutgoingTerminal = false, want true (tracked + terminal)")
+	}
+	if pending := s.PeekInbox(); len(pending) != 0 {
+		t.Fatalf("inbox size = %d, want 0 (empty reply must be suppressed)", len(pending))
+	}
+}
+
+// TestEvictTerminalReapsDeliveredOutgoingReplies verifies the stale-re-render
+// fix: aged one-shot outgoing-reply records are evicted by identity, while a
+// fresh reply and genuine incoming messages survive.
+func TestEvictTerminalReapsDeliveredOutgoingReplies(t *testing.T) {
+	s := NewStore()
+	now := time.Now()
+	oldTS := now.Add(-20 * time.Minute).UTC().Format(time.RFC3339)
+	freshTS := now.UTC().Format(time.RFC3339)
+	s.mu.Lock()
+	s.inbox = []a2a.Message{
+		{MessageID: "reply-old", TaskID: "old", Metadata: map[string]any{"kind": "outgoing-reply", "ts": oldTS}},
+		{MessageID: "reply-fresh", TaskID: "fresh", Metadata: map[string]any{"kind": "outgoing-reply", "ts": freshTS}},
+		{MessageID: "incoming-1", TaskID: "inc"}, // genuine incoming, no ts → never evicted
+	}
+	s.mu.Unlock()
+
+	s.evictTerminal(now)
+
+	got := s.PeekInbox()
+	if len(got) != 2 {
+		t.Fatalf("inbox size after evict = %d, want 2 (aged reply reaped)", len(got))
+	}
+	for _, m := range got {
+		if m.MessageID == "reply-old" {
+			t.Fatal("reply-old should have been evicted")
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Two defects in the inbox relay path produce noise + unbounded re-rendering for agents that poll their inbox:

1. **Empty synthetic replies.** When a peer completes an outbound task with **no reply text** (e.g. a bare completion ack), `appendSyntheticReply` still appended a synthetic `[reply]` record with an empty body to the originator's inbox. The terminal state is already recorded on the task, so a contentless completion adds only noise.

2. **Stale outgoing-reply re-render.** One-shot outgoing-reply notifications (MessageID prefix `reply-`) are delivered in real time and are **never** completed by their own originator, so `CompleteTask`'s by-taskID drop never reaches them. They were never evicted and re-rendered on every poll, growing without bound.

## Fix (both in `internal/agent/store.go`)

1. `appendSyntheticReply`: early-return when `strings.TrimSpace(reply) == ""`; otherwise stamp a `ts` (RFC3339) on the record.
2. `evictTerminal`: evict inbox records whose `MessageID` has prefix `reply-` once their `ts` is older than a 10-minute delivery TTL (matched by identity, since `kind` is stripped on disk). Fresh replies and genuine incoming messages (no `ts`) are untouched.

## Tests

Adds `TestIngestOutgoingTerminalSkipsEmptyReply` and `TestEvictTerminalReapsDeliveredOutgoingReplies`. `go build ./cmd/a2abridge`, full `go test ./internal/agent/`, and `gofmt` all clean on current `main` (962a37a).
